### PR TITLE
add approved column in trip table

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -13,7 +13,8 @@ class TripsController < ApplicationController
     @trips =
       Trip
       .includes(:user, places: :pictures)
-      .where.not(user_id: current_user.try(:id))
+      .where.not(user_id: current_user.try(:id),
+                 approved: false)
       .order(created_at: :desc)
       .limit(6)
       .offset(offset)
@@ -73,7 +74,9 @@ class TripsController < ApplicationController
     @trips =
       Trip
       .includes(:user, places: :pictures)
-      .where.not(user_id: current_user.try(:id))
+      .where.not(user_id: current_user.try(:id), 
+                 approved: false
+        )
       .tagged_with(params[:keywords].try(:split), any: true)
       .order(created_at: :desc)
       .offset(page)
@@ -94,7 +97,9 @@ class TripsController < ApplicationController
     @trips =
       Trip
       .includes(:user, places: :pictures)
-      .where.not(user_id: current_user.try(:id))
+      .where.not(user_id: current_user.try(:id),
+        approved: false
+        )
       .order(cached_weighted_average: :desc)
       .limit(6)
       .offset(offset)

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -17,6 +17,7 @@
 #  cached_weighted_total   :integer          default(0)
 #  cached_weighted_average :float            default(0.0)
 #  impressions_count       :integer          default(0)
+#  approved                :boolean          default(FALSE)
 #
 
 class Trip < ApplicationRecord

--- a/app/serializers/trip_serializer.rb
+++ b/app/serializers/trip_serializer.rb
@@ -17,6 +17,7 @@
 #  cached_weighted_total   :integer          default(0)
 #  cached_weighted_average :float            default(0.0)
 #  impressions_count       :integer          default(0)
+#  approved                :boolean          default(FALSE)
 #
 
 class TripSerializer < ActiveModel::Serializer

--- a/db/migrate/20170303091217_add_approved_col_to_trip.rb
+++ b/db/migrate/20170303091217_add_approved_col_to_trip.rb
@@ -1,0 +1,5 @@
+class AddApprovedColToTrip < ActiveRecord::Migration[5.0]
+  def change
+    add_column :trips, :approved, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170224085655) do
+ActiveRecord::Schema.define(version: 20170303091217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,8 +125,8 @@ ActiveRecord::Schema.define(version: 20170224085655) do
     t.string   "name"
     t.text     "description"
     t.boolean  "status"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
     t.integer  "user_id"
     t.integer  "cached_votes_total",      default: 0
     t.integer  "cached_votes_score",      default: 0
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 20170224085655) do
     t.integer  "cached_weighted_total",   default: 0
     t.float    "cached_weighted_average", default: 0.0
     t.integer  "impressions_count",       default: 0
+    t.boolean  "approved",                default: false
     t.index ["cached_votes_down"], name: "index_trips_on_cached_votes_down", using: :btree
     t.index ["cached_votes_score"], name: "index_trips_on_cached_votes_score", using: :btree
     t.index ["cached_votes_total"], name: "index_trips_on_cached_votes_total", using: :btree

--- a/test/fixtures/trips.yml
+++ b/test/fixtures/trips.yml
@@ -17,6 +17,7 @@
 #  cached_weighted_total   :integer          default(0)
 #  cached_weighted_average :float            default(0.0)
 #  impressions_count       :integer          default(0)
+#  approved                :boolean          default(FALSE)
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/trip_test.rb
+++ b/test/models/trip_test.rb
@@ -17,6 +17,7 @@
 #  cached_weighted_total   :integer          default(0)
 #  cached_weighted_average :float            default(0.0)
 #  impressions_count       :integer          default(0)
+#  approved                :boolean          default(FALSE)
 #
 
 require 'test_helper'


### PR DESCRIPTION
1. Trips which are not approved by admin are not shown on dashboard only approved ones.
2. Trips that are not approved can be seen on the individual user's page.